### PR TITLE
Fix for removal of deviceType

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.10
     hooks:
       - id: actionlint
     # Note: shellcheck cannot directly parse YAML; actionlint extracts workflow
@@ -31,7 +31,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.14.10
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -280,27 +280,32 @@ class RESTClient(MyAirClient):
     ) -> None:
         if "errors" in resp_dict:
             try:
-                error_message: str = f"{resp_dict['errors'][0]['errorInfo']['errorType']}: {resp_dict['errors'][0]['errorInfo']['errorCode']}"
-                if resp_dict["errors"][0]["errorInfo"]["errorType"] == "unauthorized":
-                    if step == "gql_query" and not initial:
-                        raise ParsingError(
+                if "errorInfo" in resp_dict["errors"][0]:
+                    error_message: str = f"{resp_dict['errors'][0]['errorInfo']['errorType']}: {resp_dict['errors'][0]['errorInfo']['errorCode']}"
+                    if resp_dict["errors"][0]["errorInfo"]["errorType"] == "unauthorized":
+                        if step == "gql_query" and not initial:
+                            raise ParsingError(
+                                f"Getting unauthorized error on {step} step. {error_message}"
+                            )
+                        raise AuthenticationError(
                             f"Getting unauthorized error on {step} step. {error_message}"
                         )
-                    raise AuthenticationError(
-                        f"Getting unauthorized error on {step} step. {error_message}"
-                    )
-                if resp_dict["errors"][0]["errorInfo"]["errorType"] == "badRequest" and resp_dict[
-                    "errors"
-                ][0]["errorInfo"]["errorCode"] in {
-                    "onboardingFlowInProgress",
-                    "equipmentNotAssigned",
-                }:
-                    raise IncompleteAccountError(f"{error_message}")
-            except TypeError:
-                error_message = "Error"
+                    if resp_dict["errors"][0]["errorInfo"][
+                        "errorType"
+                    ] == "badRequest" and resp_dict["errors"][0]["errorInfo"]["errorCode"] in {
+                        "onboardingFlowInProgress",
+                        "equipmentNotAssigned",
+                    }:
+                        raise IncompleteAccountError(f"{error_message}")
+                elif "message" in resp_dict["errors"][0]:
+                    error_message = resp_dict["errors"][0]["message"]
+                else:
+                    error_message = str(resp_dict["errors"][0])
+            except (TypeError, KeyError) as e:
+                error_message = f"Unable to parse error message. {type(e).__name__}: {e}"
             raise HttpProcessingError(
                 code=response.status,
-                message=f"{step} step: {error_message}. {resp_dict})",
+                message=f"{step} step: {error_message}. {resp_dict}",
                 headers=CIMultiDict(response.headers),
             )
 
@@ -637,14 +642,17 @@ class RESTClient(MyAirClient):
         query: str = """
         query getPatientWrapper {
             getPatientWrapper {
+                masks {
+                    maskCode
+                }
                 fgDevices {
                     serialNumber
-                    deviceType
-                    lastSleepDataReportTime
                     localizedName
+                    deviceSeries
+                    deviceFamily
+                    lastSleepDataReportTime
                     fgDeviceManufacturerName
                     fgDevicePatientId
-                    __typename
                 }
             }
         }
@@ -656,10 +664,18 @@ class RESTClient(MyAirClient):
         )
         _LOGGER.debug("[get_user_device_data] records_dict: %s", redact_dict(records_dict))
         try:
-            device: Mapping[str, Any] = records_dict["data"]["getPatientWrapper"]["fgDevices"][0]
+            device: dict[str, Any] = records_dict["data"]["getPatientWrapper"]["fgDevices"][0]
         except Exception as e:
             _LOGGER.error("Error getting User Device Data. %s: %s", type(e).__name__, e)
             raise ParsingError("Error getting User Device Data") from e
+        mask_code: str | None = None
+        try:
+            mask_code = records_dict["data"]["getPatientWrapper"]["masks"][0]["maskCode"]
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning("Error getting User Mask Data. %s: %s", type(e).__name__, e)
+        else:
+            if mask_code:
+                device["maskCode"] = mask_code
         if not isinstance(device, dict):
             _LOGGER.error("Error getting User Device Data. Returned data is not a dict")
             raise ParsingError("Error getting User Device Data. Returned data is not a dict")

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -88,7 +88,7 @@ async def test_extract_and_update_cookies_variants(
     client._cookie_dt = initial_dt
     client._cookie_sid = initial_sid
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         await client._extract_and_update_cookies(cookie_headers)
     assert client._cookie_dt == expected_dt
     assert client._cookie_sid == expected_sid
@@ -100,6 +100,12 @@ async def test_extract_and_update_cookies_variants(
         )
     else:
         assert "Changing Device Token" not in caplog.text
+
+    # Check sid update logging when sid changed from a non-None value
+    if initial_sid is not None and expected_sid is not None and initial_sid != expected_sid:
+        assert "Updating to new sid cookie" in caplog.text
+    else:
+        assert "Updating to new sid cookie" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -854,6 +860,41 @@ async def test_get_user_device_data_failure_variants(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "masks,expect_warning,expected_mask",
+    [
+        ([{"maskCode": "MASK123"}], False, "MASK123"),
+        ([{"maskCode": ""}], False, None),
+        ([], True, None),
+    ],
+)
+async def test_get_user_device_data_masks_variants(
+    config_na, session, masks, expect_warning, expected_mask, monkeypatch, caplog
+):
+    """Parametrized tests for masks behavior in get_user_device_data."""
+    client = RESTClient(config_na, session)
+    client._access_token = "access"
+    client._country_code = "US"
+
+    device = {"serialNumber": "12345"}
+    mock_response = {"data": {"getPatientWrapper": {"fgDevices": [device], "masks": masks}}}
+    monkeypatch.setattr(client, "_gql_query", AsyncMock(return_value=mock_response))
+
+    with caplog.at_level(logging.WARNING):
+        result = await client.get_user_device_data()
+
+    if expect_warning:
+        assert "Error getting User Mask Data" in caplog.text
+    else:
+        assert "Error getting User Mask Data" not in caplog.text
+
+    if expected_mask:
+        assert result["maskCode"] == expected_mask
+    else:
+        assert "maskCode" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "cookie_headers, expected_extract_arg",
     [
         (["DT=token; Path=/;"], ["DT=token; Path=/;"]),
@@ -1005,3 +1046,23 @@ async def test_status_helpers_variants(
     monkeypatch.setattr(RESTClient, "_resmed_response_error_check", AsyncMock())
     result = await getattr(client, method_name)()
     assert result is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resp_dict,expected_substring",
+    [
+        ({"errors": [{"message": "custom error message"}]}, "custom error message"),
+        ({"errors": [{"foo": "bar"}]}, "'foo': 'bar'"),
+        ({"errors": [{"errorInfo": None}]}, "Unable to parse error message"),
+    ],
+)
+async def test_resmed_response_error_check_parsing_variants(resp_dict, expected_substring):
+    """Parametrized: check various parsing fallbacks in _resmed_response_error_check."""
+    response = MagicMock(spec=ClientResponse)
+    response.status = 400
+    response.headers = CIMultiDict()
+
+    with pytest.raises(HttpProcessingError) as exc:
+        await RESTClient._resmed_response_error_check("any_step", response, resp_dict)
+    assert expected_substring in str(exc.value)


### PR DESCRIPTION
This pull request updates dependencies and improves error handling and data extraction in the `rest_client.py` file for the ResMed MyAir integration. The most significant changes include updating pre-commit hooks, enhancing error message parsing, and expanding the GraphQL query and result parsing to include mask information.

**Dependency updates:**

* Updated `actionlint` pre-commit hook from `v1.7.7` to `v1.7.10` in `.pre-commit-config.yaml`
* Updated `ruff-pre-commit` hook from `v0.13.0` to `v0.14.10` in `.pre-commit-config.yaml`

**Error handling improvements:**

* Improved error extraction logic in `_resmed_response_error_check` to handle missing keys more gracefully, provide clearer messages, and catch both `TypeError` and `KeyError` exceptions [[1]](diffhunk://#diff-e71b7efe316c8624bd5adeb7d8ad8292667d0bcfee19ce098bafaa1310e88c6aR283) [[2]](diffhunk://#diff-e71b7efe316c8624bd5adeb7d8ad8292667d0bcfee19ce098bafaa1310e88c6aL292-R305)

**Device and mask data extraction:**

* Expanded the `get_user_device_data` GraphQL query to include `masks` (with `maskCode`) and additional device fields (`deviceSeries`, `deviceFamily`)
* Enhanced parsing logic in `get_user_device_data` to extract the mask code and attach it to the device dictionary if available, with error handling for missing mask data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling versions.

* **Bug Fixes**
  * Improved error handling with clearer messages and more robust parsing of error responses.

* **New Features**
  * Device data retrieval now surfaces additional configuration info (mask identifier when available).

* **Tests**
  * Added tests covering device-mask variants and error-parsing scenarios; adjusted cookie-related logging expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->