### PR TITLE
Fix Mask Leak Units

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Features
 
-This integration creates sensors from your myAir CPAP data like AHI Events/hr, Usage Minutes, Mask On/Off count, Mask Leak %. There is also a Last Sleep Data Recorded sensor to tell you the last date that myAir has recorded. This can be used to, say, notify you of your scores when they are updated in myAir in the morning.
+This integration creates sensors from your myAir CPAP data like AHI Events/hr, Usage Minutes, Mask On/Off count, and Mask Leak in L/min. There is also a Last Sleep Data Recorded sensor to tell you the last date that myAir has recorded. This can be used to, say, notify you of your scores when they are updated in myAir in the morning.
 
 By the nature of CPAP data, sensors will only update once per day (assuming your CPAP is used every day). For this reason, the integration only polls every 30 minutes. A service exists for each config that will force update if you want to automate the sync after you wake up.
 
@@ -38,7 +38,7 @@ By the nature of CPAP data, sensors will only update once per day (assuming your
 1. CPAP Mask On/Off Count
 1. CPAP Current Data Date
     * This is the last date currently being displayed by the other sensors
-1. CPAP Mask Leak %
+1. CPAP Mask Leak
 1. CPAP Total myAir Score
 1. CPAP Sleep Data Last Collected
     * This is the datetime the CPAP uploaded the most recent data

--- a/custom_components/resmed_myair/const.py
+++ b/custom_components/resmed_myair/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, Platform, UnitOfTime
+from homeassistant.const import Platform, UnitOfTime, UnitOfVolumeFlowRate
 
 VERSION = "v0.2.6"
 
@@ -68,10 +68,10 @@ SLEEP_RECORD_SENSOR_DESCRIPTIONS: Mapping[str, SensorEntityDescription] = {
     "CPAP Current Data Date": SensorEntityDescription(
         key="startDate", device_class=SensorDeviceClass.DATE
     ),
-    "CPAP Mask Leak %": SensorEntityDescription(
+    "CPAP Mask Leak": SensorEntityDescription(
         key="leakPercentile",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     ),
     "CPAP Total myAir Score": SensorEntityDescription(
         key="sleepScore", state_class=SensorStateClass.MEASUREMENT

--- a/custom_components/resmed_myair/const.py
+++ b/custom_components/resmed_myair/const.py
@@ -68,9 +68,12 @@ SLEEP_RECORD_SENSOR_DESCRIPTIONS: Mapping[str, SensorEntityDescription] = {
     "CPAP Current Data Date": SensorEntityDescription(
         key="startDate", device_class=SensorDeviceClass.DATE
     ),
+    # Key remains leakPercentile even though units changed from % to L/min
+    # to not lose sensor history
     "CPAP Mask Leak": SensorEntityDescription(
         key="leakPercentile",
         state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     ),
     "CPAP Total myAir Score": SensorEntityDescription(

--- a/custom_components/resmed_myair/const.py
+++ b/custom_components/resmed_myair/const.py
@@ -75,6 +75,8 @@ SLEEP_RECORD_SENSOR_DESCRIPTIONS: Mapping[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+        suggested_display_precision=1,
+        icon="mdi:face-mask",
     ),
     "CPAP Total myAir Score": SensorEntityDescription(
         key="sleepScore", state_class=SensorStateClass.MEASUREMENT

--- a/custom_components/resmed_myair/recorder.py
+++ b/custom_components/resmed_myair/recorder.py
@@ -1,0 +1,31 @@
+"""Recorder platform support for resmed_myair statistics migrations."""
+
+from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+
+_MASK_LEAK_UNIQUE_ID_SUFFIX = "_leakPercentile"
+
+
+@callback
+def async_custom_equivalent_units(hass: HomeAssistant) -> dict[str, dict[str | None, str]]:
+    """Return custom equivalent units for long-term statistics migrations.
+
+    Args:
+        hass: Home Assistant instance with the entity registry.
+
+    Returns:
+        Entity-specific mappings from the old mask-leak unit to the supported
+        volume flow rate unit. The value conversion is 1:1.
+    """
+    entity_registry = er.async_get(hass)
+
+    return {
+        entry.entity_id: {PERCENTAGE: UnitOfVolumeFlowRate.LITERS_PER_MINUTE}
+        for entry in entity_registry.entities.values()
+        if entry.platform == DOMAIN
+        and entry.unique_id.startswith(f"{DOMAIN}_")
+        and entry.unique_id.endswith(_MASK_LEAK_UNIQUE_ID_SUFFIX)
+    }

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,40 @@
+"""Recorder platform tests for statistics unit migrations."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
+
+from custom_components.resmed_myair import recorder
+
+
+def test_async_custom_equivalent_units_maps_mask_leak_entities(
+    monkeypatch: Any,
+) -> None:
+    """Mask leak statistics migrate from percent to liters per minute."""
+    registry = SimpleNamespace(
+        entities={
+            "sensor.cpap_mask_leak": SimpleNamespace(
+                entity_id="sensor.cpap_mask_leak",
+                platform="resmed_myair",
+                unique_id="resmed_myair_SN123_leakPercentile",
+            ),
+            "sensor.cpap_usage_minutes": SimpleNamespace(
+                entity_id="sensor.cpap_usage_minutes",
+                platform="resmed_myair",
+                unique_id="resmed_myair_SN123_totalUsage",
+            ),
+            "sensor.other_mask_leak": SimpleNamespace(
+                entity_id="sensor.other_mask_leak",
+                platform="other",
+                unique_id="other_SN123_leakPercentile",
+            ),
+        }
+    )
+    monkeypatch.setattr(recorder.er, "async_get", lambda hass: registry)
+
+    assert recorder.async_custom_equivalent_units(SimpleNamespace()) == {
+        "sensor.cpap_mask_leak": {
+            PERCENTAGE: UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+        },
+    }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -111,6 +111,7 @@ def test_most_recent_sleep_date_all_branches(
         # For date parsing, we use a string and monkeypatch dt_util.parse_date in the test body
         ([{"foo": "2024-07-18"}], "foo", SensorDeviceClass.DATE, "2024-07-18", True),
         ([{"foo": "some string"}], "foo", None, "some string", True),
+        ([{"leakPercentile": 12.5}], "leakPercentile", None, 12.5, True),
     ],
 )
 def test_sleep_record_sensor_handle_coordinator_update(
@@ -132,7 +133,12 @@ def test_sleep_record_sensor_handle_coordinator_update(
         )
         expected_value = parsed_date
 
-    desc = SensorEntityDescription(key=sensor_key, device_class=device_class)
+    if sensor_key == "leakPercentile":
+        desc = SLEEP_RECORD_SENSOR_DESCRIPTIONS["CPAP Mask Leak"]
+        assert desc.key == sensor_key
+        assert desc.native_unit_of_measurement == UnitOfVolumeFlowRate.LITERS_PER_MINUTE
+    else:
+        desc = SensorEntityDescription(key=sensor_key, device_class=device_class)
     data = {}
     if sleep_records is not None:
         data["sleep_records"] = sleep_records

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,10 +5,11 @@ import logging
 from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.const import UnitOfVolumeFlowRate
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.resmed_myair.const import CONF_USER_NAME
+from custom_components.resmed_myair.const import CONF_USER_NAME, SLEEP_RECORD_SENSOR_DESCRIPTIONS
 from custom_components.resmed_myair.sensor import (
     MyAirDeviceSensor,
     MyAirFriendlyUsageTime,
@@ -17,6 +18,20 @@ from custom_components.resmed_myair.sensor import (
     async_setup_entry,
 )
 from tests.conftest import CoordinatorFactory, ServiceRegistryShimLike, coordinator_data
+
+
+def test_mask_leak_sensor_uses_liters_per_minute_without_changing_raw_key(
+    coordinator_factory: CoordinatorFactory,
+) -> None:
+    """Mask leak keeps its legacy raw key while exposing the correct flow unit."""
+    description = SLEEP_RECORD_SENSOR_DESCRIPTIONS["CPAP Mask Leak"]
+    coordinator = coordinator_factory(data=coordinator_data(device={"serialNumber": "SN123"}))
+
+    sensor = MyAirSleepRecordSensor("CPAP Mask Leak", description, coordinator)
+
+    assert description.key == "leakPercentile"
+    assert description.native_unit_of_measurement == UnitOfVolumeFlowRate.LITERS_PER_MINUTE
+    assert sensor.unique_id == "resmed_myair_SN123_leakPercentile"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CPAP Mask Leak sensor label updated (removed percent sign) and unit changed from percent to liters per minute.

* **Documentation**
  * README updated to reflect the sensor label and unit changes.

* **Chores**
  * Added support to migrate historical statistics for mask leak units to the new liters-per-minute unit.

* **Tests**
  * Added and updated tests to verify mask leak sensor configuration and statistics migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->