### PR TITLE
Fix mask leak statistics unit migration

### DIFF
--- a/custom_components/resmed_myair/__init__.py
+++ b/custom_components/resmed_myair/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     VERSION,
 )
 from .coordinator import MyAirDataUpdateCoordinator
+from .recorder import async_migrate_mask_leak_statistics_metadata
 from .redaction import redact_dict
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -61,6 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     config_entry.runtime_data = coordinator
 
     await coordinator.async_config_entry_first_refresh()
+
+    async_migrate_mask_leak_statistics_metadata(hass)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True

--- a/custom_components/resmed_myair/manifest.json
+++ b/custom_components/resmed_myair/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "resmed_myair",
   "name": "ResMed myAir",
+  "after_dependencies": [
+    "recorder"
+  ],
   "codeowners": [
     "@prestomation",
     "@Snuffy2"
   ],
   "config_flow": true,
-  "after_dependencies": [
-    "recorder"
-  ],
   "dependencies": [
     "sensor"
   ],

--- a/custom_components/resmed_myair/manifest.json
+++ b/custom_components/resmed_myair/manifest.json
@@ -7,6 +7,7 @@
   ],
   "config_flow": true,
   "dependencies": [
+    "recorder",
     "sensor"
   ],
   "documentation": "https://github.com/prestomation/resmed_myair_sensors",

--- a/custom_components/resmed_myair/manifest.json
+++ b/custom_components/resmed_myair/manifest.json
@@ -6,8 +6,10 @@
     "@Snuffy2"
   ],
   "config_flow": true,
+  "after_dependencies": [
+    "recorder"
+  ],
   "dependencies": [
-    "recorder",
     "sensor"
   ],
   "documentation": "https://github.com/prestomation/resmed_myair_sensors",

--- a/custom_components/resmed_myair/recorder.py
+++ b/custom_components/resmed_myair/recorder.py
@@ -4,6 +4,7 @@ from homeassistant.components.recorder import get_instance
 from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE
 from homeassistant.util.unit_conversion import VolumeFlowRateConverter
 
 from .const import DOMAIN
@@ -39,6 +40,9 @@ def async_migrate_mask_leak_statistics_metadata(hass: HomeAssistant) -> None:
     Args:
         hass: Home Assistant instance with recorder and entity registry state.
     """
+    if DATA_INSTANCE not in hass.data:
+        return
+
     recorder_instance = get_instance(hass)
 
     for entity_id in _mask_leak_entity_ids(hass):

--- a/custom_components/resmed_myair/recorder.py
+++ b/custom_components/resmed_myair/recorder.py
@@ -1,12 +1,52 @@
 """Recorder platform support for resmed_myair statistics migrations."""
 
+from homeassistant.components.recorder import get_instance
 from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_conversion import VolumeFlowRateConverter
 
 from .const import DOMAIN
 
 _MASK_LEAK_UNIQUE_ID_SUFFIX = "_leakPercentile"
+
+
+def _mask_leak_entity_ids(hass: HomeAssistant) -> list[str]:
+    """Return registered myAir mask leak entity IDs.
+
+    Args:
+        hass: Home Assistant instance with the entity registry.
+
+    Returns:
+        Entity IDs for the mask leak sensor whose previous unit metadata may
+        need migration.
+    """
+    entity_registry = er.async_get(hass)
+
+    return [
+        entry.entity_id
+        for entry in entity_registry.entities.values()
+        if entry.platform == DOMAIN
+        and entry.unique_id.startswith(f"{DOMAIN}_")
+        and entry.unique_id.endswith(_MASK_LEAK_UNIQUE_ID_SUFFIX)
+    ]
+
+
+@callback
+def async_migrate_mask_leak_statistics_metadata(hass: HomeAssistant) -> None:
+    """Relabel legacy mask leak statistics metadata to the corrected unit.
+
+    Args:
+        hass: Home Assistant instance with recorder and entity registry state.
+    """
+    recorder_instance = get_instance(hass)
+
+    for entity_id in _mask_leak_entity_ids(hass):
+        recorder_instance.async_update_statistics_metadata(
+            entity_id,
+            new_unit_class=VolumeFlowRateConverter.UNIT_CLASS,
+            new_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+        )
 
 
 @callback
@@ -20,12 +60,7 @@ def async_custom_equivalent_units(hass: HomeAssistant) -> dict[str, dict[str | N
         Entity-specific mappings from the old mask-leak unit to the supported
         volume flow rate unit. The value conversion is 1:1.
     """
-    entity_registry = er.async_get(hass)
-
     return {
-        entry.entity_id: {PERCENTAGE: UnitOfVolumeFlowRate.LITERS_PER_MINUTE}
-        for entry in entity_registry.entities.values()
-        if entry.platform == DOMAIN
-        and entry.unique_id.startswith(f"{DOMAIN}_")
-        and entry.unique_id.endswith(_MASK_LEAK_UNIQUE_ID_SUFFIX)
+        entity_id: {PERCENTAGE: UnitOfVolumeFlowRate.LITERS_PER_MINUTE}
+        for entity_id in _mask_leak_entity_ids(hass)
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -84,6 +84,7 @@ async def test_async_setup_entry_multiple_calls(
     instance = mock_coordinator.return_value
     instance.async_config_entry_first_refresh = AsyncMock()
 
+    monkeypatch.setattr(resmed_module, "async_migrate_mask_leak_statistics_metadata", MagicMock())
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
     fwd = hass.config_entries.async_forward_entry_setups
 
@@ -94,6 +95,37 @@ async def test_async_setup_entry_multiple_calls(
     assert fwd.await_count == 2
     fwd.assert_awaited_with(config_entry, PLATFORMS)
     assert instance.async_config_entry_first_refresh.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_migrates_mask_leak_statistics_metadata(
+    hass: MagicMock,
+    config_entry: MockConfigEntry,
+    session: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup schedules the mask leak statistics metadata migration before platforms load."""
+    monkeypatch.setattr(
+        resmed_module, "async_create_clientsession", lambda *args, **kwargs: session
+    )
+
+    mock_coordinator = MagicMock()
+    monkeypatch.setattr(resmed_module, "MyAirDataUpdateCoordinator", mock_coordinator)
+    mock_coordinator.return_value.async_config_entry_first_refresh = AsyncMock()
+    migrate_statistics = MagicMock()
+    monkeypatch.setattr(
+        resmed_module,
+        "async_migrate_mask_leak_statistics_metadata",
+        migrate_statistics,
+    )
+
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
+
+    result = await async_setup_entry(hass, config_entry)
+
+    assert result is True
+    migrate_statistics.assert_called_once_with(hass)
+    hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(config_entry, PLATFORMS)
 
 
 @pytest.mark.asyncio
@@ -469,6 +501,7 @@ async def test_force_poll_service_triggers_refresh(
     monkeypatch.setattr(
         resmed_module, "MyAirDataUpdateCoordinator", lambda *a, **k: dummy_coordinator
     )
+    monkeypatch.setattr(resmed_module, "async_migrate_mask_leak_statistics_metadata", MagicMock())
     monkeypatch.setattr(
         sensor_platform, "MyAirDataUpdateCoordinator", lambda *a, **k: dummy_coordinator
     )

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -14,11 +14,12 @@ from custom_components.resmed_myair import recorder
 MANIFEST_PATH = Path(__file__).parents[1] / "custom_components/resmed_myair/manifest.json"
 
 
-def test_manifest_depends_on_recorder() -> None:
-    """Recorder platform support loads before myAir entities publish statistics."""
+def test_manifest_loads_after_recorder_when_available() -> None:
+    """Recorder support is optional but ordered before myAir when available."""
     manifest = json.loads(MANIFEST_PATH.read_text())
 
-    assert "recorder" in manifest["dependencies"]
+    assert "recorder" in manifest["after_dependencies"]
+    assert "recorder" not in manifest["dependencies"]
 
 
 def test_async_custom_equivalent_units_maps_mask_leak_entities(
@@ -75,10 +76,24 @@ def test_async_migrate_mask_leak_statistics_metadata_updates_recorder(
     monkeypatch.setattr(recorder.er, "async_get", lambda hass: registry)
     monkeypatch.setattr(recorder, "get_instance", lambda hass: recorder_instance)
 
-    recorder.async_migrate_mask_leak_statistics_metadata(SimpleNamespace())
+    recorder.async_migrate_mask_leak_statistics_metadata(
+        SimpleNamespace(data={recorder.DATA_INSTANCE: recorder_instance})
+    )
 
     recorder_instance.async_update_statistics_metadata.assert_called_once_with(
         "sensor.cpap_mask_leak",
         new_unit_class=VolumeFlowRateConverter.UNIT_CLASS,
         new_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     )
+
+
+def test_async_migrate_mask_leak_statistics_metadata_skips_without_recorder(
+    monkeypatch: Any,
+) -> None:
+    """Mask leak metadata migration does not block setup when recorder is absent."""
+    recorder_instance = SimpleNamespace(async_update_statistics_metadata=MagicMock())
+    monkeypatch.setattr(recorder, "get_instance", lambda hass: recorder_instance)
+
+    recorder.async_migrate_mask_leak_statistics_metadata(SimpleNamespace(data={}))
+
+    recorder_instance.async_update_statistics_metadata.assert_not_called()

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,11 +1,24 @@
 """Recorder platform tests for statistics unit migrations."""
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
+from homeassistant.util.unit_conversion import VolumeFlowRateConverter
 
 from custom_components.resmed_myair import recorder
+
+MANIFEST_PATH = Path(__file__).parents[1] / "custom_components/resmed_myair/manifest.json"
+
+
+def test_manifest_depends_on_recorder() -> None:
+    """Recorder platform support loads before myAir entities publish statistics."""
+    manifest = json.loads(MANIFEST_PATH.read_text())
+
+    assert "recorder" in manifest["dependencies"]
 
 
 def test_async_custom_equivalent_units_maps_mask_leak_entities(
@@ -38,3 +51,34 @@ def test_async_custom_equivalent_units_maps_mask_leak_entities(
             PERCENTAGE: UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
         },
     }
+
+
+def test_async_migrate_mask_leak_statistics_metadata_updates_recorder(
+    monkeypatch: Any,
+) -> None:
+    """Mask leak statistics metadata is relabeled to the new flow-rate unit."""
+    registry = SimpleNamespace(
+        entities={
+            "sensor.cpap_mask_leak": SimpleNamespace(
+                entity_id="sensor.cpap_mask_leak",
+                platform="resmed_myair",
+                unique_id="resmed_myair_SN123_leakPercentile",
+            ),
+            "sensor.cpap_usage_minutes": SimpleNamespace(
+                entity_id="sensor.cpap_usage_minutes",
+                platform="resmed_myair",
+                unique_id="resmed_myair_SN123_totalUsage",
+            ),
+        }
+    )
+    recorder_instance = SimpleNamespace(async_update_statistics_metadata=MagicMock())
+    monkeypatch.setattr(recorder.er, "async_get", lambda hass: registry)
+    monkeypatch.setattr(recorder, "get_instance", lambda hass: recorder_instance)
+
+    recorder.async_migrate_mask_leak_statistics_metadata(SimpleNamespace())
+
+    recorder_instance.async_update_statistics_metadata.assert_called_once_with(
+        "sensor.cpap_mask_leak",
+        new_unit_class=VolumeFlowRateConverter.UNIT_CLASS,
+        new_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mask-leak statistics metadata now undergoes automatic migration during component setup, applying proper flow-rate unit classification and displaying values in liters-per-minute for consistency.

* **Chores**
  * Recorder component is now a required integration dependency.

* **Tests**
  * Added tests validating statistics metadata migration behavior and recorder dependency compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->